### PR TITLE
[#118762237] Increase device type max length

### DIFF
--- a/misfitapp/migrations/0004_increase_devicetype_maxlength.py
+++ b/misfitapp/migrations/0004_increase_devicetype_maxlength.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('misfitapp', '0003_auto_20151009_1702'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='device',
+            name='device_type',
+            field=models.CharField(max_length=64, choices=[(b'shine', b'shine')]),
+        ),
+    ]

--- a/misfitapp/models.py
+++ b/misfitapp/models.py
@@ -168,7 +168,7 @@ class Device(MisfitModel):
 
     id = models.CharField(max_length=MAX_KEY_LEN, primary_key=True)
     user = models.ForeignKey(UserModel)
-    device_type = models.CharField(choices=DEVICE_TYPES, max_length=5)
+    device_type = models.CharField(choices=DEVICE_TYPES, max_length=64)
     serial_number = models.CharField(max_length=100)
     firmware_version = models.CharField(max_length=100)
     battery_level = models.SmallIntegerField()

--- a/misfitapp/models.py
+++ b/misfitapp/models.py
@@ -164,11 +164,9 @@ class Profile(MisfitModel):
 
 @python_2_unicode_compatible
 class Device(MisfitModel):
-    DEVICE_TYPES = (('shine', 'shine'),)
-
     id = models.CharField(max_length=MAX_KEY_LEN, primary_key=True)
     user = models.ForeignKey(UserModel)
-    device_type = models.CharField(choices=DEVICE_TYPES, max_length=64)
+    device_type = models.CharField(max_length=64)
     serial_number = models.CharField(max_length=100)
     firmware_version = models.CharField(max_length=100)
     battery_level = models.SmallIntegerField()


### PR DESCRIPTION
@orcasgit/orcas-developers Please review. This should take care of the following warning/messages/error:
`Task misfitapp.tasks.import_historical_cls reject requeue=False: value too long for type character varying(5)`